### PR TITLE
Fix outated syntax

### DIFF
--- a/src/fs.mbt
+++ b/src/fs.mbt
@@ -9,7 +9,7 @@
 /// ```text
 /// @firefly.load_file("font")
 /// ```
-pub typealias Bytes as Path
+pub type Path = Bytes
 
 ///|
 /// Get size (in bytes) of a file from ROM or the data directory.

--- a/src/input.mbt
+++ b/src/input.mbt
@@ -8,8 +8,8 @@ pub fn read_pad(peer? : Peer = Peer::combined()) -> Pad? {
     0xffff => None
     raw =>
       Some(Pad::{
-        x: (raw >> 16).reinterpret_as_int().to_int16().to_int(),
-        y: raw.reinterpret_as_int().to_int16().to_int(),
+        x: Int16::from_int((raw >> 16).reinterpret_as_int()).to_int(),
+        y: Int16::from_int(raw.reinterpret_as_int()).to_int(),
       })
   }
 }

--- a/src/input_pad.mbt
+++ b/src/input_pad.mbt
@@ -75,7 +75,9 @@ pub fn Pad::as_dpad(self : Pad) -> DPad {
 ///
 /// [polar coordinate]: https://en.wikipedia.org/wiki/Polar_coordinate_system
 pub fn Pad::as_angle(self : Pad) -> Angle {
-  Angle::from_rad(PI / 2 * @math.atan2f(self.y.to_float(), self.x.to_float()))
+  Angle::from_rad(
+    PI / 2 * @math.atan2f(Float::from_int(self.y), Float::from_int(self.x)),
+  )
 }
 
 ///|
@@ -83,7 +85,7 @@ pub fn Pad::as_angle(self : Pad) -> Angle {
 ///
 /// If the `Pad` is at `{x: 0, y: 0}`, then this returns 0.
 pub fn Pad::length(self : Pad) -> Float {
-  (self.x * self.x + self.y * self.y).to_float().sqrt()
+  Float::from_int(self.x * self.x + self.y * self.y).sqrt()
 }
 
 ///|

--- a/src/misc.mbt
+++ b/src/misc.mbt
@@ -44,7 +44,7 @@ pub fn get_random() -> UInt {
 pub fn get_name(peer : Peer) -> Bytes {
   let arr = FixedArray::make(16, Byte::default())
   let len = @ffi.get_name(peer.raw, @memory.fixedbytes_addr(arr))
-  Bytes::from_fixedarray(arr, len~)
+  Bytes::from_array(arr[:len])
 }
 
 ///|

--- a/src/random/top.mbt
+++ b/src/random/top.mbt
@@ -8,7 +8,7 @@ pub fn double() -> Double {
 ///|
 /// Returns a random 32-bit `Float` in the range `[0.0, 1.0)`
 pub fn float() -> Float {
-  (uint() << 8 >> 8).to_float() / (1U << 24).to_float()
+  Float::from_uint(uint() << 8 >> 8) / Float::from_uint(1U << 24)
 }
 
 ///|


### PR DESCRIPTION
They changed:

- `XX::to_float` &rarr; `Float::from_xx` in <https://github.com/moonbitlang/core/pull/2952>
- `XX::to_int16` &rarr; `Int16::from_xx` in <https://github.com/moonbitlang/core/pull/2981>
- also they changed the type alias syntax, as announced in <https://www.moonbitlang.com/weekly-updates/2025/11/03/index#compiler-updates>

I've not found any motivations on this in either the PRs, issues, or on their blog posts. I did find in <https://www.moonbitlang.com/weekly-updates/2025/12/02/index#standard-library-and-experimental-library-update> a small note that they're recommending `XX::from_array` instead of the `XX::of`, which sounds adjacent but doesn't strictly explain their change on `Int16` and `Float`.

The old functions have been marked as deprecated (e.g <https://github.com/moonbitlang/core/blob/8649000e93c3a5db4393ec1264049c65e04b3434/builtin/intrinsics.mbt#L2563-L2577>) so let's follow the deprecation warning hints.

Maybe the Firefly MoonBit SDK should also try adopt some of these patterns, but that'll be a separate PR.
