### PR TITLE
Fix version comments on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v5
+      - uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0
 
   moonbit:
     runs-on: ubuntu-latest
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
+      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -40,7 +40,7 @@ jobs:
           key: ${{ runner.os }}-moonbit-${{ hashFiles('**/moon.mod.json') }}
           restore-keys: |
             ${{ runner.os }}-moonbit-
-      - uses: hustcer/setup-moonbit@66fdadf7f54f35045a7dc6357f43b1fdd1909405 # v1
+      - uses: hustcer/setup-moonbit@66fdadf7f54f35045a7dc6357f43b1fdd1909405 # v1.17
       - run: moon update
       - run: task lint test:moonbit
       # TODO(@orsinium): Install firefly_cli on CI and enable tests.


### PR DESCRIPTION
The version comment must match the exact version, not just the version alias.

The setup-moonbit action is special because it doesn't have a full semver tag, but instead only major.minor: https://github.com/hustcer/setup-moonbit/tags

this issue was reported here: https://github.com/firefly-zero/firefly-moon/security/code-scanning/2
