### PR TITLE
Rename Firefly CLI to 'ff' & use it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,29 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+
+      - name: Setup Taskfile
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
         with:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/cache@v5
+
+      - name: Cache MoonBit dependencies
+        uses: actions/cache@v5
         with:
           path: ~/.moon/registry
           key: ${{ runner.os }}-moonbit-${{ hashFiles('**/moon.mod.json') }}
           restore-keys: |
             ${{ runner.os }}-moonbit-
-      - uses: hustcer/setup-moonbit@66fdadf7f54f35045a7dc6357f43b1fdd1909405 # v1.17
-      - run: moon update
-      - run: task lint test:moonbit
-      # TODO(@orsinium): Install firefly_cli on CI and enable tests.
-      # - run: task test
+
+      - name: Install Firefly Zero CLI
+        run: bash -c "$(curl https://fireflyzero.com/install.sh)"
+
+      - name: Setup MoonBit
+        uses: hustcer/setup-moonbit@66fdadf7f54f35045a7dc6357f43b1fdd1909405 # v1.17
+
+      - name: Update MoonBit package registry
+        run: moon update
+
+      - name: Run tests
+        run: task lint test

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,7 +47,7 @@ tasks:
   test:firefly:
     cmds:
       - for: { var: EXAMPLES }
-        cmd: firefly_cli build {{.ITEM}}
+        cmd: ff build {{.ITEM}}
 
   all:
     cmds:

--- a/example/README.md
+++ b/example/README.md
@@ -11,7 +11,7 @@ You need these to run the examples:
 - Clone this Git repo: <https://github.com/firefly-zero/firefly-moon>
 - MoonBit CLI (`moon`): <https://www.moonbitlang.com/download#moonbit-cli-tools>
 - Taskfile CLI (`task`): <https://taskfile.dev/>
-- Firefly Zero CLI (`firefly_cli`): <https://docs.fireflyzero.com/user/installation/#-cli>
+- Firefly Zero CLI (`ff`): <https://docs.fireflyzero.com/user/installation/#-cli>
 - Firefly Zero emulator (`firefly-emulator`): <https://docs.fireflyzero.com/user/installation/#-emulator>
 
 To run one of the examples then execute the listed command from the root of


### PR DESCRIPTION
- Renames `firefly_cli` to `ff` in Taskfile
- Use new install script in CI
