### PR TITLE
Set parameters for nodes

### DIFF
--- a/src/audio/nodes.mbt
+++ b/src/audio/nodes.mbt
@@ -227,8 +227,8 @@ pub fn[Mod : Modulator] Pause::modulate(
 /// Modulate the cut-off frequency.
 pub fn[Mod : Modulator] LowPass::modulate(
   self : LowPass,
-  low : Float,
-  high : Float,
+  low : Hz,
+  high : Hz,
   mod : Mod,
 ) -> Unit {
   mod.modulate(self.id(), 0, low, high)
@@ -238,8 +238,8 @@ pub fn[Mod : Modulator] LowPass::modulate(
 /// Modulate the cut-off frequency.
 pub fn[Mod : Modulator] HighPass::modulate(
   self : HighPass,
-  low : Float,
-  high : Float,
+  low : Hz,
+  high : Hz,
   mod : Mod,
 ) -> Unit {
   mod.modulate(self.id(), 0, low, high)
@@ -278,4 +278,68 @@ pub fn[Mod : Modulator] Clip::modulate_high(
   mod : Mod,
 ) -> Unit {
   mod.modulate(self.id(), 2, low, high)
+}
+
+///|
+/// Set the gain level.
+pub fn Gain::set(self : Gain, val : Float) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, val)
+}
+
+///|
+/// Set the pan value (from 0. to 1.: 0. is only left, 1. is only right).
+pub fn Pan::set(self : Pan, val : Float) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, val)
+}
+
+///|
+pub fn Mute::mute(self : Mute) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, 0)
+}
+
+///|
+pub fn Mute::unmute(self : Mute) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, 1)
+}
+
+///|
+pub fn Pause::pause(self : Pause) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, 0)
+}
+
+///|
+pub fn Pause::play(self : Pause) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, 1)
+}
+
+///|
+/// Set the cut-off frequency.
+pub fn LowPass::set(self : LowPass, val : Hz) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, val)
+}
+
+///|
+/// Set the cut-off frequency.
+pub fn HighPass::set(self : HighPass, val : Hz) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, val)
+}
+
+///|
+/// Set the low cut amplitude and adjust the high amplitude to keep the gap.
+///
+/// In other words, the difference between low and high cut points will stay the same.
+pub fn Clip::set_both(self : Clip, val : Float) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, val)
+}
+
+///|
+/// Set the low cut amplitude.
+pub fn Clip::set_low(self : Clip, val : Float) -> Unit {
+  @ffi.audio_set_param(self.id(), 1, val)
+}
+
+///|
+/// Set the high cut amplitude.
+pub fn Clip::set_high(self : Clip, val : Float) -> Unit {
+  @ffi.audio_set_param(self.id(), 2, val)
 }

--- a/src/audio/source_nodes.mbt
+++ b/src/audio/source_nodes.mbt
@@ -129,3 +129,34 @@ pub fn[Mod : Modulator] Triangle::modulate(
 ) -> Unit {
   mod.modulate(self.id(), 0, low, high)
 }
+
+///|
+/// Set oscillation frequency.
+pub fn Sine::set(self : Sine, val : Hz) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, val)
+}
+
+///|
+/// Set oscillation frequency.
+pub fn Square::set(self : Square, val : Hz) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, val)
+}
+
+///|
+/// Set oscillation frequency.
+pub fn Sawtooth::set(self : Sawtooth, val : Hz) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, val)
+}
+
+///|
+/// Set oscillation frequency.
+pub fn Triangle::set(self : Triangle, val : Hz) -> Unit {
+  @ffi.audio_set_param(self.id(), 0, val)
+}
+
+///|
+/// Go to the specified timestamp in the file.
+pub fn File::seek(self : File, t : Time) -> Unit {
+  let val = Float::from_uint(t.0)
+  @ffi.audio_set_param(self.id(), 0, val)
+}

--- a/src/internal/ffi/audio.mbt
+++ b/src/internal/ffi/audio.mbt
@@ -100,18 +100,21 @@ pub fn audio_add_clip(parent_id : UInt, low : Float, high : Float) -> UInt = "au
 
 ///|
 /// Reset the node state to how it was when it was just added.
-pub fn audio_reset(node_id : UInt) -> Unit = "audio" "reset"
+pub fn audio_reset(node_id : UInt) = "audio" "reset"
 
 ///|
 /// Reset the node and all child nodes to the state to how it was when they were just added.
-pub fn audio_reset_all(node_id : UInt) -> Unit = "audio" "reset_all"
+pub fn audio_reset_all(node_id : UInt) = "audio" "reset_all"
 
 ///|
 ///  Remove all child nodes.
 ///
 /// After it is called, you should make sure to discard all references to the
 /// old child nodes.
-pub fn audio_clear(node_id : UInt) -> Unit = "audio" "clear"
+pub fn audio_clear(node_id : UInt) = "audio" "clear"
+
+///|
+pub fn audio_set_param(node_id : UInt, param : UInt, val : Float) = "audio" "set_param"
 
 ///|
 /// Linear (ramp up or down) envelope.


### PR DESCRIPTION
Add `set` methods for some nodes to set their parameters. Any parameter that can be modulated can be also set manually.